### PR TITLE
prevent concurrent mod exception on observe()

### DIFF
--- a/app/src/main/java/org/openziti/mobile/ZitiContextModel.kt
+++ b/app/src/main/java/org/openziti/mobile/ZitiContextModel.kt
@@ -51,7 +51,7 @@ class ZitiContextModel(val ctx: ZitiContext): ViewModel() {
                     ZitiContext.ServiceUpdate.ConfigurationChange -> {}
                 }
 
-                servicesData.postValue(servicesMap.values)
+                servicesData.postValue(servicesMap.values.toList())
             }
         }
     }


### PR DESCRIPTION
from crash report
```java.util.ConcurrentModificationException: 
  at java.util.TreeMap$PrivateEntryIterator.nextEntry (TreeMap.java:1238)
  at java.util.TreeMap$ValueIterator.next (TreeMap.java:1283)
  at org.openziti.mobile.ZitiMobileEdgeActivity$onCreate$31$5$4.onChanged (ZitiMobileEdgeActivity.kt:432)
  at org.openziti.mobile.ZitiMobileEdgeActivity$onCreate$31$5$4.onChanged (ZitiMobileEdgeActivity.kt:47)
  at androidx.lifecycle.LiveData.considerNotify (LiveData.java:131)
  at androidx.lifecycle.LiveData.dispatchingValue (LiveData.java:149)
  at androidx.lifecycle.LiveData.setValue (LiveData.java:307)
  at androidx.lifecycle.MutableLiveData.setValue (MutableLiveData.java:50)
  at androidx.lifecycle.LiveData$1.run (LiveData.java:91)
  at android.os.Handler.handleCallback (Handler.java:790)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:164)
  at android.app.ActivityThread.main (ActivityThread.java:7000)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:441)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1408)
```