### PR TITLE
Bump tunnel sdk

### DIFF
--- a/app/src/main/java/org/openziti/mobile/model/Identity.kt
+++ b/app/src/main/java/org/openziti/mobile/model/Identity.kt
@@ -50,7 +50,7 @@ class Identity(
     fun status(): LiveData<String> = status
     internal val status = MutableLiveData("Loading")
 
-    private val controllers = MutableLiveData(cfg.controllers?.toList() ?: listOf(cfg.controller))
+    private val controllers = MutableLiveData(cfg.controllers.toList())
     fun controllers() = controllers
 
     private val enabled = MutableLiveData(enable)
@@ -61,9 +61,11 @@ class Identity(
     fun services(): LiveData<List<Service>> = services
 
     fun refresh() {
-        tunnel.refreshIdentity(id).handleAsync { _, ex ->
-            ex?.let {
-                Log.w(TunnelModel.TAG, "failed refresh", it)
+        if (status.value == "Active") {
+            tunnel.refreshIdentity(id).handleAsync { _, ex ->
+                ex?.let {
+                    Log.w(TunnelModel.TAG, "failed refresh", it)
+                }
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ android = "8.10.0"
 kotlin = "2.1.21"
 
 # ziti projects
-ziti-tunnel-sdk = "v1.5.12"
+ziti-tunnel-sdk = "v1.6.0"
 
 # 3rd part deps
 kotlinx-serialization-json = "1.8.1"

--- a/tunnel/src/main/java/org/openziti/tunnel/Tunnel.kt
+++ b/tunnel/src/main/java/org/openziti/tunnel/Tunnel.kt
@@ -46,7 +46,7 @@ class Tunnel(app: Application, ): Runnable {
     fun onEvent(json: String) {
         Log.i(TAG, "event: $json")
         events.trySend(json).onFailure {
-            Log.w(TAG, "failed to queue event", it)
+            Log.w(TAG, "failed to queue event$json", it)
         }
     }
 
@@ -78,11 +78,13 @@ class Tunnel(app: Application, ): Runnable {
     }
 
     fun events() = flow {
-        val ev = events.receive()
-        runCatching {
-            emit(EventsJson.decodeFromString<Event>(ev))
-        }.onFailure {
-            Log.w(TAG, "failed to parse event: $ev", it)
+        while(true) {
+            val ev = events.receive()
+            runCatching {
+                emit(EventsJson.decodeFromString<Event>(ev))
+            }.onFailure {
+                Log.w(TAG, "failed to parse event: $ev", it)
+            }
         }
     }
 


### PR DESCRIPTION
Multiple fixes for operating on HA networks

- avoid certain race condition during initial load (in HA)
- Tunneler SDK update [v1.6.0](https://github.com/openziti/ziti-tunnel-sdk-c/releases/tag/v1.6.0)
- Ziti SDK update [v1.6.5](https://github.com/openziti/ziti-sdk-c/compare/1.6.1...1.6.5)