### PR TITLE
use Android NDK r28

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,6 +80,7 @@ android {
     }
 
     compileSdk = 36
+    ndkVersion = libs.versions.ndk.get()
 
     defaultConfig {
         applicationId = "org.openziti.mobile"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 # plugins
 android = "8.11.1"
 kotlin = "2.2.0"
+ndk = "28.2.13676358"
 
 # ziti projects
 ziti-tunnel-sdk = "v1.6.0"


### PR DESCRIPTION

this is to ensure compliance with [page sizes requirements](https://developer.android.com/guide/practices/page-sizes) 
ensure consistent NDK version usage