### PR TITLE
update openziti tunnel sdk to v1.7.11

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ kotlin = "2.2.10"
 ndk = "28.2.13676358"
 
 # ziti projects
-ziti-tunnel-sdk = "v1.7.5"
+ziti-tunnel-sdk = "v1.7.11"
 
 # 3rd part deps
 kotlinx-serialization-json = "1.9.0"


### PR DESCRIPTION
updates ziti sdk: [1.7.10 -> 1.8.3](https://github.com/openziti/ziti-sdk-c/compare/1.7.10...1.8.3)