### PR TITLE
Bump the github-actions group with 3 updates

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: install contemporary cmake
-      uses: lukka/get-cmake@v3.30.1
+      uses: lukka/get-cmake@v4.3.2
     - uses: lukka/run-vcpkg@v11
     - name: build ${{ inputs.target }}
       shell: bash

--- a/.github/actions/gradle/action.yml
+++ b/.github/actions/gradle/action.yml
@@ -27,16 +27,16 @@ runs:
   using: "composite"
   steps:
     - name: install contemporary cmake
-      uses: lukka/get-cmake@v3.30.1
+      uses: lukka/get-cmake@v4.3.2
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         pattern: dependencies-*
         merge-multiple: true
         path: tunnel/build/cmake/
 
     - name: set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: 21
         distribution: temurin

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,4 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 # CI cmake version
-cmake.version=3.30.1
+cmake.version=4.3.2


### PR DESCRIPTION
Bumps the following actions across 2 files:
- lukka/get-cmake from v3.30.1 to v4.3.2
- actions/download-artifact from v4 to v8
- actions/setup-java from v4 to v5