### PR TITLE
update tunnel-sdk

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ kotlin = "2.4.0"
 ndk = "28.2.13676358"
 
 # ziti projects
-ziti-tunnel-sdk = "v1.15.2"
+ziti-tunnel-sdk = "v1.17.1"
 
 # 3rd part deps
 kotlinx-serialization-json = "1.11.0"


### PR DESCRIPTION
- ziti-tunnel-sdk@1.17.1
- ziti-sdk@1.17.1

Fixes:
- (possibly)[fixes #240] SIGBUS crash on arm-v7a